### PR TITLE
Adding modbins.json to describe where modpack binaries can be resolved

### DIFF
--- a/mod_root/modbins.json
+++ b/mod_root/modbins.json
@@ -1,0 +1,9 @@
+{
+    "modpack-binaries":
+    [
+        {
+            "type": "treeZip",
+            "uri": "https://niflheim.blob.core.windows.net/modpack-binaries/Niflheim-ModBins-1.1.1.zip"
+        }
+    ]
+}


### PR DESCRIPTION
Adding modbins.json to describe where modpack binaries can be resolved by packaging/installer automation.  For future use by installer tooling or packaging tooling to merge binaries and configuration sets.