### PR TITLE
slight buff to multiplayer scaling

### DIFF
--- a/mod_root/BepInEx/config/org.bepinex.plugins.creaturelevelcontrol.cfg
+++ b/mod_root/BepInEx/config/org.bepinex.plugins.creaturelevelcontrol.cfg
@@ -33,13 +33,13 @@ Use configuration yaml = On
 # Setting type: Single
 # Default value: 40
 # Acceptable value range: From 0 to 200
-HP increase per player in multiplayer (percentage) = 40
+HP increase per player in multiplayer (percentage) = 75
 
 ## Damage increase per player in multiplayer in percent.
 # Setting type: Single
 # Default value: 4
 # Acceptable value range: From 0 to 200
-DMG increase per player in multiplayer (percentage) = 4
+DMG increase per player in multiplayer (percentage) = 7
 
 ## Sets the minimum player count for multiplayer games.
 # Setting type: Int32
@@ -63,7 +63,7 @@ Player count to be added to the actual player count for multiplayer scaling (0 i
 # Setting type: Single
 # Default value: 200
 # Acceptable value range: From 0 to 10000
-Multiplayer scaling per player range (0 is unlimited) = 200
+Multiplayer scaling per player range (0 is unlimited) = 350
 
 ## Maximum distance for the nameplate to be shown on mouseover.
 # Setting type: Single


### PR DESCRIPTION
Changes to the way multiplayer scaling works 
 - Makes enemies spongier when more players are around
 - Makes enemies hit a bit harder
 - Makes the area that counts as "nearby" for terms of scaling a bit bigger (about half the vertical height of a fully zoomed in map)